### PR TITLE
Refactor: to be using constant instead literal

### DIFF
--- a/src/exe_name.rs
+++ b/src/exe_name.rs
@@ -1,16 +1,16 @@
+use crate::{error, paths::lade_build_path};
 use std::fs;
 
-use crate::{error, paths::lade_build_path};
-
+const ERRMSG: &str = "Failed to read exec_name";
 pub fn get_exec_name() -> String {
     let path = lade_build_path().join("exec_name");
     if path.exists() {
         return fs::read_to_string(path).unwrap_or_else(|_| {
-            error!("Failed to read exec_name", "Failed to read exec_name");
+            error!(ERRMSG, ERRMSG);
         });
     }
 
     fs::read_to_string(path).unwrap_or_else(|_| {
-        error!("Failed to read exec_name", "Failed to read exec_name");
+        error!(ERRMSG, ERRMSG);
     })
 }


### PR DESCRIPTION
Because there's many same literal 